### PR TITLE
Support env api_key

### DIFF
--- a/lua/sam_llm/init.lua
+++ b/lua/sam_llm/init.lua
@@ -2,11 +2,15 @@ local M = {}
 
 local defaults = {
   model = "something",
-  endpoint = "something"
+  endpoint = "something",
+  api_key = nil,
 }
 
 function M.setup(opts)
   M.config = vim.tbl_deep_extend("force", {}, defaults, opts or {})
+  if not M.config.api_key then
+    M.config.api_key = os.getenv("ANTHROPIC_API_KEY")
+  end
 end
 
 local function sam_llm_debug(text) 


### PR DESCRIPTION
## Summary
- default the `api_key` setting to `nil`
- if no key is provided in `setup`, read `ANTHROPIC_API_KEY` from the environment

## Testing
- `lua` was not available in the environment, so no tests were run

------
https://chatgpt.com/codex/tasks/task_b_68451194e540832c8735c59725891415