### PR TITLE
Add log file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # sam_llm
+
+Responses from the API are appended to a log file located at
+`<nvim stdpath('cache')>/sam_llm.log` for debugging purposes.
+

--- a/lua/sam_llm/init.lua
+++ b/lua/sam_llm/init.lua
@@ -13,8 +13,18 @@ function M.setup(opts)
   end
 end
 
-local function sam_llm_debug(text) 
+local function sam_llm_debug(text)
   vim.notify(text, vim.log.levels.DEBUG)
+end
+
+local log_file = vim.fn.stdpath("cache") .. "/sam_llm.log"
+
+local function append_log(text)
+  local f = io.open(log_file, "a")
+  if f then
+    f:write(os.date("%Y-%m-%d %H:%M:%S") .. " " .. text .. "\n")
+    f:close()
+  end
 end
 
 function M.process(_)
@@ -50,7 +60,9 @@ function M.process(_)
     vim.fn.json_encode(payload),
     M.config.endpoint,
   }
-  vim.fn.system(cmd)
+  local result = vim.fn.system(cmd)
+  append_log(result)
 end
 
 return M
+


### PR DESCRIPTION
## Summary
- implement `append_log` to write debug info to a log file
- log Anthropic API responses for debugging
- document log file location

## Testing
- `luacheck --version` *(fails: command not found)*
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68451a6f7260832cbc866f1bdd384c99