### PR TITLE
Add buffer backup and response handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 Responses from the API are appended to a log file located at
 `<nvim stdpath('cache')>/sam_llm.log` for debugging purposes.
 
+When `LlmProcess` runs the current buffer is backed up to
+`<nvim stdpath('cache')>/sam_lua/<date>` with a filename based on the
+original buffer name and a timestamp. The extracted response can be backed up
+in the same location. These backups are controlled with the
+`backup_original` and `backup_response` configuration options.
+


### PR DESCRIPTION
## Summary
- add backup options to `defaults`
- store original buffer and API response in cache with dated directories
- parse API JSON and replace buffer with returned text
- document backup features

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684575f29e04832c8e1b21d451a411a2